### PR TITLE
OmniAuthの脆弱性対策

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ gem 'devise-i18n'
 gem 'devise-i18n-views'
 gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
+gem "omniauth-rails_csrf_protection"
 gem 'recaptcha', require: "recaptcha/rails"
 gem 'rack-cors'
 gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,9 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     payjp (0.0.6)
       rest-client (~> 2.0)
@@ -426,6 +429,7 @@ DEPENDENCIES
   mysql2 (>= 0.4.4, < 0.6.0)
   omniauth-facebook
   omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   payjp
   pry-byebug
   pry-rails

--- a/app/views/devise/registrations/index.html.haml
+++ b/app/views/devise/registrations/index.html.haml
@@ -8,9 +8,9 @@
     = link_to new_user_registration_path, class: 'devise-main__registration__link__email' do
       %i.far.fa-envelope
       メールアドレスで登録
-    = link_to user_facebook_omniauth_authorize_path, class: 'devise-main__registration__link__facebook'  do
+    = link_to user_facebook_omniauth_authorize_path, method: :post, class: 'devise-main__registration__link__facebook'  do
       %i.fab.fa-facebook
       Facebookで登録
-    = link_to user_google_oauth2_omniauth_authorize_path, class: 'devise-main__registration__link__google' do
+    = link_to user_google_oauth2_omniauth_authorize_path, method: :post, class: 'devise-main__registration__link__google' do
       %i.fab.fa-google-plus-g
       Googleで登録


### PR DESCRIPTION
# WHAT
- OmniAuthの脆弱性対策
- gem omniauth-rails_csrf_protection のインストール

# WHY
- クロスサイトリクエストフォージェリ（CSRF）に対しての脆弱性を解消するため